### PR TITLE
[PS-350] Bumping Faraday gem to v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 .ruby-version
 .yardoc
 .rake_tasks~
-Gemfile.lock
 coverage/*
 doc/*
 log/*

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,8 +4,8 @@ PATH
     bigcommerce (1.0.1)
       faraday (< 3)
       faraday-gzip (< 2)
-      hashie (~> 3.4)
-      jwt (~> 1.5.4)
+      hashie (< 6)
+      jwt (< 3)
 
 GEM
   remote: https://rubygems.org/
@@ -21,9 +21,9 @@ GEM
       faraday (>= 1.0)
       zlib (~> 2.1)
     faraday-net_http (3.0.2)
-    hashie (3.6.0)
+    hashie (5.0.0)
     json (2.6.3)
-    jwt (1.5.6)
+    jwt (2.7.0)
     method_source (1.0.0)
     parallel (1.23.0)
     parser (3.2.2.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,87 @@
+PATH
+  remote: .
+  specs:
+    bigcommerce (1.0.1)
+      faraday (< 3)
+      faraday-gzip (< 2)
+      hashie (~> 3.4)
+      jwt (~> 1.5.4)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    coderay (1.1.3)
+    diff-lcs (1.5.0)
+    docile (1.4.0)
+    faraday (2.7.4)
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-gzip (1.0.0)
+      faraday (>= 1.0)
+      zlib (~> 2.1)
+    faraday-net_http (3.0.2)
+    hashie (3.6.0)
+    json (2.6.3)
+    jwt (1.5.6)
+    method_source (1.0.0)
+    parallel (1.23.0)
+    parser (3.2.2.1)
+      ast (~> 2.4.1)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    rainbow (3.1.1)
+    rake (13.0.6)
+    regexp_parser (2.8.0)
+    rexml (3.2.5)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.2)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.0)
+    rubocop (1.50.2)
+      json (~> 2.3)
+      parallel (~> 1.10)
+      parser (>= 3.2.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.28.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.28.0)
+      parser (>= 3.2.1.0)
+    ruby-progressbar (1.13.0)
+    ruby2_keywords (0.0.5)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
+    unicode-display_width (2.4.2)
+    zlib (2.1.1)
+
+PLATFORMS
+  arm64-darwin-21
+
+DEPENDENCIES
+  bigcommerce!
+  bundler
+  pry
+  rake
+  rspec
+  rubocop
+  simplecov
+
+BUNDLED WITH
+   2.3.26

--- a/bigcommerce.gemspec
+++ b/bigcommerce.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'rake'
 
-  s.add_dependency 'faraday', '~> 0.11'
-  s.add_dependency 'faraday_middleware', '~> 0.11'
+  s.add_dependency 'faraday', '< 3'
+  s.add_dependency 'faraday-gzip', '< 2'
   s.add_dependency 'hashie', '~> 3.4'
   s.add_dependency 'jwt', '~> 1.5.4'
 end

--- a/bigcommerce.gemspec
+++ b/bigcommerce.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'faraday', '< 3'
   s.add_dependency 'faraday-gzip', '< 2'
-  s.add_dependency 'hashie', '~> 3.4'
-  s.add_dependency 'jwt', '~> 1.5.4'
+  s.add_dependency 'hashie', '< 6'
+  s.add_dependency 'jwt', '< 3'
 end

--- a/lib/bigcommerce.rb
+++ b/lib/bigcommerce.rb
@@ -1,5 +1,5 @@
 require 'hashie'
-require 'faraday_middleware'
+require 'faraday/gzip'
 require 'bigcommerce/version'
 require 'bigcommerce/config'
 require 'bigcommerce/connection'

--- a/lib/bigcommerce/connection.rb
+++ b/lib/bigcommerce/connection.rb
@@ -13,12 +13,12 @@ module Bigcommerce
         conn.request :json
         conn.headers = HEADERS
         if config.auth == 'legacy'
-          conn.use Faraday::Request::BasicAuthentication, config.username, config.api_key
+          conn.use Faraday::Request::Authorization, config.username, config.api_key
         else
           conn.use Bigcommerce::Middleware::Auth, config
         end
         conn.use Bigcommerce::Middleware::HttpException
-        conn.use FaradayMiddleware::Gzip
+        conn.request :gzip
         conn.adapter Faraday.default_adapter
       end
     end

--- a/lib/bigcommerce/middleware/http_exception.rb
+++ b/lib/bigcommerce/middleware/http_exception.rb
@@ -2,7 +2,7 @@ require 'bigcommerce/exception'
 
 module Bigcommerce
   module Middleware
-    class HttpException < Faraday::Response::Middleware
+    class HttpException < Faraday::Middleware
       include Bigcommerce::HttpErrors
 
       def on_complete(env)

--- a/lib/bigcommerce/version.rb
+++ b/lib/bigcommerce/version.rb
@@ -1,3 +1,3 @@
 module Bigcommerce
-  VERSION = '1.0.1'.freeze
+  VERSION = '2.0.0'.freeze
 end

--- a/spec/bigcommerce/bigcommerce_spec.rb
+++ b/spec/bigcommerce/bigcommerce_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Bigcommerce do
       end
 
       it 'should have the correct auth middleware' do
-        expect(middleware).to include(Faraday::Request::BasicAuthentication)
+        expect(middleware).to include(Faraday::Request::Authorization)
       end
     end
 
@@ -59,7 +59,7 @@ RSpec.describe Bigcommerce do
 
       expect(Bigcommerce.api.instance_variable_get('@builder')
                 .instance_variable_get('@handlers'))
-                .to include(Faraday::Request::BasicAuthentication)
+                .to include(Faraday::Request::Authorization)
 
       Bigcommerce.configure do |config|
         config.access_token = 'jksdgkjbhksjdb'


### PR DESCRIPTION
**JIRA Ticket:** [PS-350](https://smileio.atlassian.net/browse/PS-350?atlOrigin=eyJpIjoiM2NjODgwNzI0NzZmNDViY2I4MTJhMzkyY2NkYmZlMzkiLCJwIjoiaiJ9)

# Description

This PR is part of the **Wrap-Up** phase under the  project [Smile Core Libyears Teardown](https://www.notion.so/smileteam/Smile-Core-Libyears-Teardown-a2ee09cd1c804993ab46b1a539b9e18c?pvs=4). 

## Changes

- Updated gem `faraday` to version `2.74`

As an additional effort, since these gems would likely block an update to faraday on `smile-core`
- Updated gem `hashie` to version `5`
- Updated gem `jwt` to version `2`


# How has this been tested?

## Manual testing

- Bumped the dependencies and used this gem in a boilerplate rails app, since plugging this on `smile-core` is not possible at the moment.

- Resolved the errors that popped up when trying to boot up the rails console and also fixed errors that showed up on automated specs

- Ran requests using my local store with the updated gem, by using it in the boilerplate rails app, basically pointing the gem `path` to the local modified version with the updates

   <img width="731" alt="Screen Shot 2023-04-25 at 15 28 27" src="https://user-images.githubusercontent.com/12715554/234370261-a81ba0b5-2fc9-41bf-8bd1-accf686e9ad4.png">
  
  <img width="805" alt="Screen Shot 2023-04-25 at 14 40 33" src="https://user-images.githubusercontent.com/12715554/234370563-5efe0cb6-680e-4206-b96c-e8c5755f4748.png">

  <img width="672" alt="Screen Shot 2023-04-25 at 14 52 09" src="https://user-images.githubusercontent.com/12715554/234370653-32c1ee6e-983e-437c-a480-801f86e17d16.png">
  
  ## Automated testing
  Automated tests passing after the changes
  
  <img width="957" alt="Screen Shot 2023-04-25 at 15 21 40" src="https://user-images.githubusercontent.com/12715554/234371239-2f5cd410-749c-48ad-baf1-da251d4e8b3a.png">


[PS-350]: https://smileio.atlassian.net/browse/PS-350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ