### PR TITLE
exclude empty attributes from resource hash

### DIFF
--- a/lib/bigcommerce/resources/resource.rb
+++ b/lib/bigcommerce/resources/resource.rb
@@ -6,5 +6,9 @@ module Bigcommerce
   class Resource < Hashie::Trash
     include Hashie::Extensions::MethodAccess
     include Hashie::Extensions::IgnoreUndeclared
+
+    def to_h
+      super.reject { |_, value| value.nil? }
+    end
   end
 end


### PR DESCRIPTION
## Description 

One of the major changes that occurred between version 3.x and version 5.x of the Hashie gem is the way in which the `.to_h` method handles keys with nil values.

In version 3.x, when using the `.to_h` method on a Hashie object that contained keys with nil values, those keys were simply ignored and not included in the resulting hash. However, starting with version 4.x of the Hashie gem, the `.to_h` method was updated to include keys with nil values in the resulting hash. 

With the update of the gem in https://github.com/smile-io/bigcommerce-api-ruby/pull/2, this new behavior is causing problems on Smile Core, where the hash is not being treated to not include attributes not accepted by BigC API.
So instead of applying changes in Core to account for this new behavior we'll instead make sure this gem still provides the same behavior as before.
