### PR TITLE
[COR-401] Removing rubocop gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,9 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 gemspec
 
 group :development do
-  gem 'pry'
-  gem 'rspec'
-  gem 'rubocop'
-  gem 'simplecov'
+  gem "pry"
+  gem "rspec"
+  gem "simplecov"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bigcommerce (1.0.1)
+    bigcommerce (2.0.0)
       faraday (< 3)
       faraday-gzip (< 2)
       hashie (< 6)
@@ -10,31 +10,31 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.4.2)
+    base64 (0.3.0)
     coderay (1.1.3)
     diff-lcs (1.5.0)
     docile (1.4.0)
-    faraday (2.7.4)
-      faraday-net_http (>= 2.0, < 3.1)
-      ruby2_keywords (>= 0.0.4)
+    faraday (2.13.1)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
     faraday-gzip (1.0.0)
       faraday (>= 1.0)
       zlib (~> 2.1)
-    faraday-net_http (3.0.2)
+    faraday-net_http (3.4.0)
+      net-http (>= 0.5.0)
     hashie (5.0.0)
-    json (2.6.3)
-    jwt (2.7.0)
+    json (2.12.2)
+    jwt (2.10.1)
+      base64
+    logger (1.7.0)
     method_source (1.0.0)
-    parallel (1.23.0)
-    parser (3.2.2.1)
-      ast (~> 2.4.1)
+    net-http (0.6.0)
+      uri
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    rainbow (3.1.1)
     rake (13.0.6)
-    regexp_parser (2.8.0)
-    rexml (3.2.5)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
@@ -48,31 +48,18 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
-    rubocop (1.50.2)
-      json (~> 2.3)
-      parallel (~> 1.10)
-      parser (>= 3.2.0.0)
-      rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.8, < 3.0)
-      rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.28.0, < 2.0)
-      ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.28.0)
-      parser (>= 3.2.1.0)
-    ruby-progressbar (1.13.0)
-    ruby2_keywords (0.0.5)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    unicode-display_width (2.4.2)
+    uri (1.0.3)
     zlib (2.1.1)
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-24
 
 DEPENDENCIES
   bigcommerce!
@@ -80,7 +67,6 @@ DEPENDENCIES
   pry
   rake
   rspec
-  rubocop
   simplecov
 
 BUNDLED WITH

--- a/bigcommerce.gemspec
+++ b/bigcommerce.gemspec
@@ -1,27 +1,27 @@
-lib = File.expand_path('lib', __dir__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'bigcommerce/version'
+require "bigcommerce/version"
 
 Gem::Specification.new do |s|
-  s.name = 'bigcommerce'
+  s.name = "bigcommerce"
   s.version = Bigcommerce::VERSION
   s.platform = Gem::Platform::RUBY
-  s.required_ruby_version = '>= 2.0.0'
-  s.license = 'MIT'
+  s.required_ruby_version = ">= 2.0.0"
+  s.license = "MIT"
 
-  s.authors = ['BigCommerce Engineering']
-  s.homepage = 'https://github.com/bigcommerce/bigcommerce-api-ruby'
-  s.summary = 'Ruby client library for the BigCommerce API'
+  s.authors = ["BigCommerce Engineering"]
+  s.homepage = "https://github.com/bigcommerce/bigcommerce-api-ruby"
+  s.summary = "Ruby client library for the BigCommerce API"
   s.description = s.summary
 
-  s.require_paths = ['lib']
-  s.files = Dir['README.md', 'lib/**/*', 'bigcommerce.gemspec']
+  s.require_paths = ["lib"]
+  s.files = Dir["README.md", "lib/**/*", "bigcommerce.gemspec"]
 
-  s.add_development_dependency 'bundler'
-  s.add_development_dependency 'rake'
+  s.add_development_dependency "bundler"
+  s.add_development_dependency "rake"
 
-  s.add_dependency 'faraday', '< 3'
-  s.add_dependency 'faraday-gzip', '< 2'
-  s.add_dependency 'hashie', '< 6'
-  s.add_dependency 'jwt', '< 3'
+  s.add_dependency "faraday", "< 3"
+  s.add_dependency "faraday-gzip", "< 2"
+  s.add_dependency "hashie", "< 6"
+  s.add_dependency "jwt", "< 3"
 end


### PR DESCRIPTION
#### What?

We decided to drop the `rubocop` gem since one of its dependencies `rexml` introduced security vulnerabilities
<img width="1408" alt="Screenshot 2025-06-02 at 14 24 53" src="https://github.com/user-attachments/assets/a23fcbf6-7049-42a3-a215-bc8cbc4df1e5" />

We plan to eventually stop using this fork, so we won't replace `rubocop` with `standard` here.