### PR TITLE
[COR-1388] Allow jwt 3.x to unblock CVE-2026-45363 fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       faraday (< 3)
       faraday-gzip (< 4)
       hashie (< 6)
-      jwt (< 3)
+      jwt (< 4)
 
 GEM
   remote: https://rubygems.org/

--- a/bigcommerce.gemspec
+++ b/bigcommerce.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |s|
   s.add_dependency "faraday", "< 3"
   s.add_dependency "faraday-gzip", "< 4"
   s.add_dependency "hashie", "< 6"
-  s.add_dependency "jwt", "< 3"
+  s.add_dependency "jwt", "< 4"
 end


### PR DESCRIPTION
**LINEAR Ticket:** [COR-1388](https://linear.app/smile/issue/COR-1388)

# Description

Bump the `jwt` gem cap in this fork from `< 3` to `< 4` so that smile-core can upgrade to `jwt 3.2.0+`, which fixes [CVE-2026-45363](https://github.com/jwt/ruby-jwt/security/advisories/GHSA-c32j-vqhx-rx3x) (HMAC empty-key bypass — High, CVSS 7.4).

Currently smile-core is blocked from moving off jwt 2.10.x because Bundler can't resolve `jwt 3.x` while this fork pins `< 3`.

## What changed

```ruby
-  s.add_dependency "jwt", "< 3"
+  s.add_dependency "jwt", "< 4"
```

(Plus the corresponding lockfile line.)

## Why this is safe

The only `jwt` API call in this gem is in `lib/bigcommerce/resources/customers/customer.rb#login_token`:

```ruby
JWT.encode(payload, config.client_secret, 'HS256')
```

`JWT.encode` with HS256 is fully forward-compatible with `jwt 3.x` — none of the v3.0 breaking changes touch this surface (no `JWT::EncodedToken`, no deprecated claim validators, no RSA/EdDSA, no HS512256).

Verified by reading the upstream [3.0.0 release notes](https://github.com/jwt/ruby-jwt/releases/tag/v3.0.0) and the [upgrade guide](https://github.com/jwt/ruby-jwt/blob/main/UPGRADING.md).

# How has this been tested?

## Automated testing

- `bundle install` resolves cleanly with `jwt (< 4)`.
- `bundle exec rspec` produces the same 47/91 failures already present on `master` — none are JWT-related (they're `count` endpoint specs broken by the v3 path change).

# Deployment dependencies

- Required by the follow-up smile-core PR that bumps jwt to `~> 3.2`.

# Rollback instructions

Revert this PR; smile-core stays on jwt 2.10.x. No published gem to yank (consumed via git ref).
