### PR TITLE
[COR-1388] Bump jwt + faraday in lockfile to clear Dependabot alerts

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,23 +14,23 @@ GEM
     coderay (1.1.3)
     diff-lcs (1.5.0)
     docile (1.4.0)
-    faraday (2.14.1)
+    faraday (2.14.2)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
     faraday-gzip (3.1.0)
       faraday (>= 2.0, < 3)
       zlib (~> 3.0)
-    faraday-net_http (3.4.0)
-      net-http (>= 0.5.0)
+    faraday-net_http (3.4.3)
+      net-http (~> 0.5)
     hashie (5.0.0)
-    json (2.12.2)
-    jwt (2.10.1)
+    json (2.19.7)
+    jwt (3.2.0)
       base64
     logger (1.7.0)
     method_source (1.0.0)
-    net-http (0.6.0)
-      uri
+    net-http (0.9.1)
+      uri (>= 0.11.1)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -75,15 +75,15 @@ CHECKSUMS
   coderay (1.1.3) sha256=dc530018a4684512f8f38143cd2a096c9f02a1fc2459edcfe534787a7fc77d4b
   diff-lcs (1.5.0) sha256=49b934001c8c6aedb37ba19daec5c634da27b318a7a3c654ae979d6ba1929b67
   docile (1.4.0) sha256=5f1734bde23721245c20c3d723e76c104208e1aa01277a69901ce770f0ebb8d3
-  faraday (2.14.1) sha256=a43cceedc1e39d188f4d2cdd360a8aaa6a11da0c407052e426ba8d3fb42ef61c
+  faraday (2.14.2) sha256=73ccb9994a9e8648f010e32eca2ae82e41c57860aa10932cda29418b9e0223ad
   faraday-gzip (3.1.0) sha256=320783690be169f9b7ddde11598b77156951343753f66a9ab98b1f6694433ff8
-  faraday-net_http (3.4.0) sha256=a1f1e4cd6a2cf21599c8221595e27582d9936819977bbd4089a601f24c64e54a
+  faraday-net_http (3.4.3) sha256=9db13becec9312f345a769eeeecf9049c9287d54c0ae053d7235228993a4eec1
   hashie (5.0.0) sha256=9d6c4e51f2a36d4616cbc8a322d619a162d8f42815a792596039fc95595603da
-  json (2.12.2) sha256=ba94a48ad265605c8fa9a50a5892f3ba6a02661aa010f638211f3cb36f44abf4
-  jwt (2.10.1) sha256=e6424ae1d813f63e761a04d6284e10e7ec531d6f701917fadcd0d9b2deaf1cc5
+  json (2.19.7) sha256=fe432c8639f6efff69f9d73b518a3705d9581ab93156f981ea72806e1e5bcc3e
+  jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   method_source (1.0.0) sha256=d779455a2b5666a079ce58577bfad8534f571af7cec8107f4dce328f0981dede
-  net-http (0.6.0) sha256=9621b20c137898af9d890556848c93603716cab516dc2c89b01a38b894e259fb
+  net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
   pry (0.14.2) sha256=c4fe54efedaca1d351280b45b8849af363184696fcac1c72e0415f9bdac4334d
   rake (13.0.6) sha256=5ce4bf5037b4196c24ac62834d8db1ce175470391026bd9e557d669beeb19097
   rspec (3.12.0) sha256=ccc41799a43509dc0be84070e3f0410ac95cbd480ae7b6c245543eb64162399c


### PR DESCRIPTION
**LINEAR Ticket:** [COR-1388](https://linear.app/smile/issue/COR-1388)

# Description

Follow-up to #8. That PR lifted the gemspec cap (`jwt < 3` → `jwt < 4`), but Dependabot scans the committed `Gemfile.lock`, which still pinned the vulnerable versions — so the fork repo still shows two open alerts. This advances the lockfile to clear them.

| Gem | Before | After | Alert |
|-----|--------|-------|-------|
| jwt | 2.10.1 | **3.2.0** | [#13](https://github.com/smile-io/bigcommerce-api-ruby/security/dependabot/13) — CVE-2026-45363, empty-key HMAC bypass (High) |
| faraday | 2.14.1 | **2.14.2** | [#11](https://github.com/smile-io/bigcommerce-api-ruby/security/dependabot/11) — CVE-2026-33637 (Low) |

Both fit within the existing gemspec caps (`jwt < 4`, `faraday < 3`) — no gemspec change needed. Transitive patch bumps came along: `json 2.12.2 → 2.19.7`, `faraday-net_http 3.4.0 → 3.4.3`, `net-http 0.6.0 → 0.9.1`.

## Scope note

This `Gemfile.lock` is only used for the fork's **own** dev/CI. Consumers (smile-core) resolve `jwt`/`faraday` against the **gemspec**, not this lockfile — smile-core is already on jwt 3.2.0 via [smile-core#13678](https://github.com/smile-io/smile-core/pull/13678). This PR exists purely to clear the alerts on this repo.

# How has this been tested?

`bundle update jwt faraday` resolved cleanly. Lockfile-only change.

# Rollback instructions

Revert this PR; no published gem (consumed via git ref).